### PR TITLE
Tag range to create changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.0] - 2022-06-21
+### :sparkles: New Features
+- [`f18f2fc`](https://github.com/sitepark-com/changelog-action/commit/f18f2fc9fbab5f50f997fd9d05f8443375093722) - Specification of a version range for the creation of a changeslog *(commit by [@sitepark-veltrup](https://github.com/sitepark-veltrup))*
+
+
 ## [v1.3.2] - 2022-05-06
 ### :bug: Bug Fixes
 - [`66a4bf2`](https://github.com/requarks/changelog-action/commit/66a4bf2663a93f4271c97e78ec54859e0b40ff95) - empty changelog warning call *(commit by [@NGPixel](https://github.com/NGPixel))*
@@ -55,3 +60,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [v1.3.1]: https://github.com/requarks/changelog-action/compare/v1.3.0...v1.3.1
 [v1.3.2]: https://github.com/requarks/changelog-action/compare/v1.3.1...v1.3.2
+[v1.4.0]: https://github.com/sitepark-com/changelog-action/compare/v1.3.2...v1.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.4.0] - 2022-06-21
-### :sparkles: New Features
-- [`f18f2fc`](https://github.com/sitepark-com/changelog-action/commit/f18f2fc9fbab5f50f997fd9d05f8443375093722) - Specification of a version range for the creation of a changeslog *(commit by [@sitepark-veltrup](https://github.com/sitepark-veltrup))*
-
-
 ## [v1.3.2] - 2022-05-06
 ### :bug: Bug Fixes
 - [`66a4bf2`](https://github.com/requarks/changelog-action/commit/66a4bf2663a93f4271c97e78ec54859e0b40ff95) - empty changelog warning call *(commit by [@NGPixel](https://github.com/NGPixel))*
@@ -60,4 +55,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [v1.3.1]: https://github.com/requarks/changelog-action/compare/v1.3.0...v1.3.1
 [v1.3.2]: https://github.com/requarks/changelog-action/compare/v1.3.1...v1.3.2
-[v1.4.0]: https://github.com/sitepark-com/changelog-action/compare/v1.3.2...v1.4.0

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ jobs:
         run: |
           name=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | tail -2 | head -1)
           echo "previousTag: $name"
-          echo "::set-output name=name::$name"
+          echo "previousTag=$name" >> $GITHUB_ENV
 
       - name: Update CHANGELOG
         id: changelog
@@ -89,7 +89,7 @@ jobs:
         with:
           token: ${{ github.token }}
           fromTag: ${{ github.ref_name }}
-          toTag: ${{ steps.previousTag.outputs.name }}
+          toTag: ${{ env.previousTag }}
 
       - name: Create Release
         uses: ncipollo/release-action@v1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Changelog from Conventional Commits - Github Action
 
-This GitHub Action automatically generates a changelog based on all the [Conventional Commits](https://www.conventionalcommits.org) between the latest tag and the previous tag.
+This GitHub Action automatically generates a changelog based on all the [Conventional Commits](https://www.conventionalcommits.org) between the latest tag and the previous tag or beween to given tags.
 
 ## Features
 
@@ -54,9 +54,58 @@ jobs:
           file_pattern: CHANGELOG.md
 ```
 
+## Example workflow with tag range
+
+This example creates a release draft. Here the tag range is used to also generate changelogs of hotfixes where the hotfix tag is not the last tag.
+
+``` yaml
+name: Create GitHub Release Draft
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  release-draft-with-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get previous tag
+        id: previousTag
+        run: |
+          name=$(git --no-pager tag --sort=creatordate --merged ${{ github.ref_name }} | tail -2 | head -1)
+          echo "previousTag: $name"
+          echo "::set-output name=name::$name"
+
+      - name: Update CHANGELOG
+        id: changelog
+        uses: sitepark-com/changelog-action@main
+        with:
+          token: ${{ github.token }}
+          fromTag: ${{ github.ref_name }}
+          toTag: ${{ steps.previousTag.outputs.name }}
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          draft: true
+          name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.changes }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ## Inputs
 * `token`: Your GitHub token (e.g. `${{ github.token }}`) - **REQUIRED**
-* `tag`: The latest tag which triggered the job. (e.g. `${{ github.ref_name }}`) - **REQUIRED**
+* `tag`: The latest tag which triggered the job. (e.g. `${{ github.ref_name }}`) - **REQUIRED or `fromTag` and `toTag`**
+* `fromTag`: The tag from which the changelog is to be determined - **REQUIRED or `tag`**
+* `toTag`: The tag up to which the changelog is to be determined - **REQUIRED or `tag`**
 * `excludeTypes`: A comma-separated list of commit types you want to exclude from the changelog (e.g. `doc,chore,perf`) - **Optional** - Default: `build,docs,other,style`
 * `writeToFile`: Should CHANGELOG.md be updated with latest changelog - **Optional** - Default: `true`
 * `useGitmojis`: Should type headers be prepended with their related gitmoji - **Optional** - Default: `true`

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Changelog from Conventional Commits'
-description: 'Generate and update the CHANGELOG from conventional commits since last tag'
+description: 'Generate and update the CHANGELOG from conventional commits since last tag or given tag range'
 author: Nicolas Giard
 inputs:
   token:
@@ -7,7 +7,13 @@ inputs:
     required: true
   tag:
     description: The latest tag (which triggered this job)
-    required: true
+    required: false
+  fromTag:
+    description: The tag from which the changelog is to be determined
+    required: false
+  toTag:
+    description: The tag up to which the changelog is to be determined
+    required: false
   excludeTypes:
     description: Types to exclude from the Changelog
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -26732,6 +26732,8 @@ function buildSubject ({ writeToFile, subject, author, authorUrl, owner, repo })
 async function main () {
   const token = core.getInput('token')
   const tag = core.getInput('tag')
+  const fromTag = core.getInput('fromTag')
+  const toTag = core.getInput('toTag')
   const excludeTypes = (core.getInput('excludeTypes') || '').split(',').map(t => t.trim())
   const writeToFile = core.getBooleanInput('writeToFile')
   const useGitmojis = core.getBooleanInput('useGitmojis')
@@ -26740,38 +26742,54 @@ async function main () {
   const repo = github.context.repo.repo
   const currentISODate = (new Date()).toISOString().substring(0, 10)
 
-  // GET LATEST + PREVIOUS TAGS
+  let latestTag = null
+  let previousTag = null
 
-  const tagsRaw = await gh.graphql(`
-    query lastTags ($owner: String!, $repo: String!) {
-      repository (owner: $owner, name: $repo) {
-        refs(first: 2, refPrefix: "refs/tags/", orderBy: { field: TAG_COMMIT_DATE, direction: DESC }) {
-          nodes {
-            name
-            target {
-              oid
+  if (tag) {
+    
+    // GET LATEST + PREVIOUS TAGS
+
+    core.info(`Using input tag: ${tag}`)
+
+    const tagsRaw = await gh.graphql(`
+      query lastTags ($owner: String!, $repo: String!) {
+        repository (owner: $owner, name: $repo) {
+          refs(first: 2, refPrefix: "refs/tags/", orderBy: { field: TAG_COMMIT_DATE, direction: DESC }) {
+            nodes {
+              name
+              target {
+                oid
+              }
             }
           }
         }
       }
+    `, {
+      owner,
+      repo
+    })
+
+    latestTag = _.get(tagsRaw, 'repository.refs.nodes[0]')
+    previousTag = _.get(tagsRaw, 'repository.refs.nodes[1]')
+  
+    if (!latestTag) {
+      return core.setFailed('Couldn\'t find the latest tag. Make sure you have an existing tag already before creating a new one.')
     }
-  `, {
-    owner,
-    repo
-  })
+    if (!previousTag) {
+      return core.setFailed('Couldn\'t find a previous tag. Make sure you have at least 2 tags already (current tag + previous initial tag).')
+    }
 
-  const latestTag = _.get(tagsRaw, 'repository.refs.nodes[0]')
-  const previousTag = _.get(tagsRaw, 'repository.refs.nodes[1]')
+    if (latestTag.name !== tag) {
+      return core.setFailed(`Provided tag doesn\'t match latest tag ${tag}.`)
+    }
+  } else if (fromTag && toTag) {
 
-  if (!latestTag) {
-    return core.setFailed('Couldn\'t find the latest tag. Make sure you have an existing tag already before creating a new one.')
-  }
-  if (!previousTag) {
-    return core.setFailed('Couldn\'t find a previous tag. Make sure you have at least 2 tags already (current tag + previous initial tag).')
-  }
+    // GET LATEST + PREVIOUS TAGS FROM INPUT
 
-  if (latestTag.name !== tag) {
-    return core.setFailed('Provided tag doesn\'t match latest tag.')
+    latestTag = { name: fromTag };
+    previousTag = { name: toTag };
+  } else {
+    return core.setFailed(`Input tag or fromTag and toTag are required.`) 
   }
 
   core.info(`Using latest tag: ${latestTag.name}`)

--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ function buildSubject ({ writeToFile, subject, author, authorUrl, owner, repo })
 async function main () {
   const token = core.getInput('token')
   const tag = core.getInput('tag')
+  const fromTag = core.getInput('fromTag')
+  const toTag = core.getInput('toTag')
   const excludeTypes = (core.getInput('excludeTypes') || '').split(',').map(t => t.trim())
   const writeToFile = core.getBooleanInput('writeToFile')
   const useGitmojis = core.getBooleanInput('useGitmojis')
@@ -60,38 +62,54 @@ async function main () {
   const repo = github.context.repo.repo
   const currentISODate = (new Date()).toISOString().substring(0, 10)
 
-  // GET LATEST + PREVIOUS TAGS
+  let latestTag = null
+  let previousTag = null
 
-  const tagsRaw = await gh.graphql(`
-    query lastTags ($owner: String!, $repo: String!) {
-      repository (owner: $owner, name: $repo) {
-        refs(first: 2, refPrefix: "refs/tags/", orderBy: { field: TAG_COMMIT_DATE, direction: DESC }) {
-          nodes {
-            name
-            target {
-              oid
+  if (tag) {
+    
+    // GET LATEST + PREVIOUS TAGS
+
+    core.info(`Using input tag: ${tag}`)
+
+    const tagsRaw = await gh.graphql(`
+      query lastTags ($owner: String!, $repo: String!) {
+        repository (owner: $owner, name: $repo) {
+          refs(first: 2, refPrefix: "refs/tags/", orderBy: { field: TAG_COMMIT_DATE, direction: DESC }) {
+            nodes {
+              name
+              target {
+                oid
+              }
             }
           }
         }
       }
+    `, {
+      owner,
+      repo
+    })
+
+    latestTag = _.get(tagsRaw, 'repository.refs.nodes[0]')
+    previousTag = _.get(tagsRaw, 'repository.refs.nodes[1]')
+  
+    if (!latestTag) {
+      return core.setFailed('Couldn\'t find the latest tag. Make sure you have an existing tag already before creating a new one.')
     }
-  `, {
-    owner,
-    repo
-  })
+    if (!previousTag) {
+      return core.setFailed('Couldn\'t find a previous tag. Make sure you have at least 2 tags already (current tag + previous initial tag).')
+    }
 
-  const latestTag = _.get(tagsRaw, 'repository.refs.nodes[0]')
-  const previousTag = _.get(tagsRaw, 'repository.refs.nodes[1]')
+    if (latestTag.name !== tag) {
+      return core.setFailed(`Provided tag doesn\'t match latest tag ${tag}.`)
+    }
+  } else if (fromTag && toTag) {
 
-  if (!latestTag) {
-    return core.setFailed('Couldn\'t find the latest tag. Make sure you have an existing tag already before creating a new one.')
-  }
-  if (!previousTag) {
-    return core.setFailed('Couldn\'t find a previous tag. Make sure you have at least 2 tags already (current tag + previous initial tag).')
-  }
+    // GET LATEST + PREVIOUS TAGS FROM INPUT
 
-  if (latestTag.name !== tag) {
-    return core.setFailed('Provided tag doesn\'t match latest tag.')
+    latestTag = { name: fromTag };
+    previousTag = { name: toTag };
+  } else {
+    return core.setFailed(`Input tag or fromTag and toTag are required.`) 
   }
 
   core.info(`Using latest tag: ${latestTag.name}`)

--- a/index.js
+++ b/index.js
@@ -256,7 +256,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   const lines = chglog.replace(/\r/g, '').split('\n')
   let firstVersionLine = _.findIndex(lines, l => l.startsWith('## '))
 
-  if (firstVersionLine >= 0 && lines[firstVersionLine].startsWith(`## [${tag}`)) {
+  if (firstVersionLine >= 0 && lines[firstVersionLine].startsWith(`## [${latestTag.name}`)) {
     return core.notice('This version already exists in the CHANGELOG! No change will be made to the CHANGELOG.')
   }
 
@@ -268,11 +268,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if (firstVersionLine > 0) {
     output += lines.slice(0, firstVersionLine).join('\n') + '\n'
   }
-  output += `## [${tag}] - ${currentISODate}\n${changes.join('\n')}\n`
+  output += `## [${latestTag.name}] - ${currentISODate}\n${changes.join('\n')}\n`
   if (firstVersionLine < lines.length) {
     output += '\n' + lines.slice(firstVersionLine).join('\n')
   }
-  output += `\n[${tag}]: https://github.com/${owner}/${repo}/compare/${previousTag.name}...${tag}`
+  output += `\n[${latestTag.name}]: https://github.com/${owner}/${repo}/compare/${previousTag.name}...${latestTag.name}`
 
   // WRITE CHANGELOG TO FILE
 


### PR DESCRIPTION
In my case I would like to create changelogs not only for the last release but also for hotfixes further back in time.

```mermaid
%%{init: { 'gitGraph': {'showCommitLabel': false}} }%%
    gitGraph
       commit tag:"1.0.0"
       commit tag:"1.1.0"
       branch hotfix/1.1.x order:2
       checkout main
       commit tag:"..."
       commit tag:"2.0.0"
       commit tag:"2.1.0"
       branch hotfix/2.1.x order:1
       commit tag:"2.1.1"
       commit tag:"2.1.2"
       commit tag:"..."
       checkout hotfix/1.1.x
       commit tag:"1.1.1"
       commit tag:"1.1.2"
       commit tag:"..."
       checkout main
       commit tag:"..."
```

Here it would help me if instead of a tag, I could specify a range over which the changelog is generated.

I still determine the necessary tag area for me about an extra script.

I use it like this:
``` yaml
name: Create GitHub Release Draft

on:
  push:
    tags:
      - [0-9]+.[0-9]+.[0-9]+

jobs:
  release-draft-with-changelog:
    runs-on: ubuntu-latest

    steps:
      - name: Checkout Code
        uses: actions/checkout@v2
        with:
          fetch-depth: 0

      - name: Get previous tag
        id: previousTag
        run: |
          name=$(git --no-pager tag --sort=-v:refname --merged ${{ github.ref_name }} | sed -n 2,2p)
          name=${name:=$(git rev-list --max-parents=0 HEAD)}
          echo "previousTag: $name"
          echo "previousTag=$name" >> $GITHUB_ENV

      - name: Update CHANGELOG
        id: changelog
        uses: sitepark-com/changelog-action@main
        with:
          token: ${{ github.token }}
          fromTag: ${{ github.ref_name }}
          toTag: ${{ env.previousTag }}

      - name: Create Release
        uses: ncipollo/release-action@v1
        with:
          allowUpdates: true
          draft: true
          name: ${{ github.ref_name }}
          body: ${{ steps.changelog.outputs.changes }}
          token: ${{ secrets.GITHUB_TOKEN }}
```