### PR TITLE
feat: `changelogFilePath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ jobs:
 | `excludeScopes` | A comma-separated list of commit scopes you want to include in the changelog (e.g. `dev,release`) | :x: | |
 | `restrictToTypes` | A comma-separated list of commit types you want to restrict to for the changelog (e.g. `feat,fix,refactor`). Overrides `excludeTypes` if defined. | :x: | |
 | `writeToFile` | Should CHANGELOG.md be updated with latest changelog | :x: | `true` |
+| `changelogFilePath` | The CHANGELOG.md file path when `writeToFile` is `true` | :x: | `CHANGELOG.md` |
 | `includeRefIssues` | Should the changelog include the issues referenced for each PR. | :x: | `true` |
 | `useGitmojis` | Should type headers be prepended with their related gitmoji | :x: | `true` |
 | `includeInvalidCommits` | Whether to include commits that don't respect the Conventional Commits format | :x: | `false` |

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: Should CHANGELOG.md be updated with latest changelog
     required: false
     default: 'true'
+  changelogFilePath:
+    description: Path to the changelog file
+    required: false
+    default: 'CHANGELOG.md'
   includeRefIssues:
     description: Should the changelog include the issues referenced for each PR.
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -5,7 +5,6 @@
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
-
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
@@ -27979,6 +27978,7 @@ async function main () {
   const excludeScopes = (core.getInput('excludeScopes') || '').split(',').map(t => t.trim()).filter(t => t)
   const restrictToTypes = (core.getInput('restrictToTypes') || '').split(',').map(t => t.trim()).filter(t => t)
   const writeToFile = core.getBooleanInput('writeToFile')
+  const changelogFilePath = core.getInput('changelogFilePath')
   const includeRefIssues = core.getBooleanInput('includeRefIssues')
   const useGitmojis = core.getBooleanInput('useGitmojis')
   const includeInvalidCommits = core.getBooleanInput('includeInvalidCommits')
@@ -28275,9 +28275,9 @@ async function main () {
 
   let chglog = ''
   try {
-    chglog = await fs.readFile('CHANGELOG.md', 'utf8')
+    chglog = await fs.readFile(changelogFilePath, 'utf8')
   } catch (err) {
-    core.info('Couldn\'t find a CHANGELOG.md, creating a new one...')
+    core.info(`Couldn\'t find a ${changelogFilePath}, creating a new one...`)
     chglog = `# Changelog
 All notable changes to this project will be documented in this file.
 
@@ -28311,7 +28311,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   // WRITE CHANGELOG TO FILE
 
-  await fs.writeFile('CHANGELOG.md', output)
+  await fs.writeFile(changelogFilePath, output)
 }
 
 main()
@@ -28320,4 +28320,3 @@ main()
 
 module.exports = __webpack_exports__;
 /******/ })()
-;

--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ async function main () {
   const excludeScopes = (core.getInput('excludeScopes') || '').split(',').map(t => t.trim()).filter(t => t)
   const restrictToTypes = (core.getInput('restrictToTypes') || '').split(',').map(t => t.trim()).filter(t => t)
   const writeToFile = core.getBooleanInput('writeToFile')
+  const changelogFilePath = core.getInput('changelogFilePath')
   const includeRefIssues = core.getBooleanInput('includeRefIssues')
   const useGitmojis = core.getBooleanInput('useGitmojis')
   const includeInvalidCommits = core.getBooleanInput('includeInvalidCommits')
@@ -367,9 +368,9 @@ async function main () {
 
   let chglog = ''
   try {
-    chglog = await fs.readFile('CHANGELOG.md', 'utf8')
+    chglog = await fs.readFile(changelogFilePath, 'utf8')
   } catch (err) {
-    core.info('Couldn\'t find a CHANGELOG.md, creating a new one...')
+    core.info(`Couldn\'t find a ${changelogFilePath}, creating a new one...`)
     chglog = `# Changelog
 All notable changes to this project will be documented in this file.
 
@@ -403,7 +404,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   // WRITE CHANGELOG TO FILE
 
-  await fs.writeFile('CHANGELOG.md', output)
+  await fs.writeFile(changelogFilePath, output)
 }
 
 main()


### PR DESCRIPTION
Sometimes you want to locate the changelog file in a different path. In my case it is `docs/CHANGELOG.md`.