### PR TITLE
fix: add end of file return to changelog file

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28309,7 +28309,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if (firstVersionLine < lines.length) {
     output += '\n' + lines.slice(firstVersionLine).join('\n')
   }
-  output += `\n[${latestTag.name}]: ${githubServerUrl}/${owner}/${repo}/compare/${previousTag.name}...${latestTag.name}`
+  output += `\n[${latestTag.name}]: ${githubServerUrl}/${owner}/${repo}/compare/${previousTag.name}...${latestTag.name}\n`
 
   // WRITE CHANGELOG TO FILE
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -28309,7 +28309,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if (firstVersionLine < lines.length) {
     output += '\n' + lines.slice(firstVersionLine).join('\n')
   }
-  output += `\n[${latestTag.name}]: ${githubServerUrl}/${owner}/${repo}/compare/${previousTag.name}...${latestTag.name}\n`
+
+  // add newline character at end of output if it doesn't already exists
+  if (!output.endsWith('\n')) {
+    output += '\n'
+  }
+  output += `[${latestTag.name}]: ${githubServerUrl}/${owner}/${repo}/compare/${previousTag.name}...${latestTag.name}\n`
 
   // WRITE CHANGELOG TO FILE
 

--- a/index.js
+++ b/index.js
@@ -401,7 +401,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if (firstVersionLine < lines.length) {
     output += '\n' + lines.slice(firstVersionLine).join('\n')
   }
-  output += `\n[${latestTag.name}]: ${githubServerUrl}/${owner}/${repo}/compare/${previousTag.name}...${latestTag.name}\n`
+
+  // add newline character at end of output if it doesn't already exists
+  if (!output.endsWith('\n')) {
+    output += '\n'
+  }
+  output += `[${latestTag.name}]: ${githubServerUrl}/${owner}/${repo}/compare/${previousTag.name}...${latestTag.name}\n`
 
   // WRITE CHANGELOG TO FILE
 

--- a/index.js
+++ b/index.js
@@ -401,7 +401,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if (firstVersionLine < lines.length) {
     output += '\n' + lines.slice(firstVersionLine).join('\n')
   }
-  output += `\n[${latestTag.name}]: ${githubServerUrl}/${owner}/${repo}/compare/${previousTag.name}...${latestTag.name}`
+  output += `\n[${latestTag.name}]: ${githubServerUrl}/${owner}/${repo}/compare/${previousTag.name}...${latestTag.name}\n`
 
   // WRITE CHANGELOG TO FILE
 


### PR DESCRIPTION
fixes https://github.com/requarks/changelog-action/issues/54

Tested from [my fork](https://github.com/sjpalf/changelog-action/releases/tag/v2.4.0) and it gives one line per link with a final newline:
<img width="631" alt="image" src="https://github.com/requarks/changelog-action/assets/18111914/2e46b691-3891-4a05-afd1-55ebdf5056d8">
